### PR TITLE
Target Spigot API 1.21 and update ACF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <minimizeJar>true</minimizeJar>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <relocations>
                                 <relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,14 @@
                         <configuration>
                             <minimizeJar>true</minimizeJar>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <filters>
+                                <filter>
+                                    <artifact>co.aikar:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.MF</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <relocations>
                                 <relocation>
                                     <pattern>co.aikar.commands</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <description>A plugin to format the outcome of '/say'</description>
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.14.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -37,7 +37,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -88,13 +88,13 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.15.2-R0.1-SNAPSHOT</version>
+            <version>1.21.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>co.aikar</groupId>
             <artifactId>acf-paper</artifactId>
-            <version>0.5.0-SNAPSHOT</version>
+            <version>0.5.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/io/github/sirmagicman/sayformat/SayFormat.java
+++ b/src/main/java/io/github/sirmagicman/sayformat/SayFormat.java
@@ -3,7 +3,6 @@ package io.github.sirmagicman.sayformat;
 import co.aikar.commands.PaperCommandManager;
 import io.github.sirmagicman.sayformat.commands.MainCommand;
 import io.github.sirmagicman.sayformat.config.MainConfig;
-import io.github.sirmagicman.sayformat.listeners.PlayerListener;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class SayFormat extends JavaPlugin {
@@ -20,7 +19,6 @@ public final class SayFormat extends JavaPlugin {
         PaperCommandManager commandManager = new PaperCommandManager(this);
         commandManager.registerCommand(new MainCommand());
         MainConfig.getInstance();
-        getServer().getPluginManager().registerEvents(new PlayerListener(), this);
     }
 
     @Override

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: SayFormat
 version: ${project.version}
 main: io.github.sirmagicman.sayformat.SayFormat
-api-version: 1.13
+api-version: 1.21
 author: SirMagicMan
 description: A plugin to format the outcome of '/say'
 website: https://www.spigotmc.org/resources/say-format.78764/


### PR DESCRIPTION
Updated Maven plugins and build against the latest Spigot API version. This also means using JDK 21.
Also updated ACF, which should disable the timings warnings when used on current Spigot versions.

Still need to update to not use deprecated methods.
